### PR TITLE
Properly convert 32-bit audio to 16-bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ You need to install Python 3.6 or later. Then you can use it from the command li
 ```
 python aup2rpp.py myProject.aup
 ```
+
+which will save the reaper file and audio dependencies in the same directory as your .aup file.

--- a/aup2rpp.py
+++ b/aup2rpp.py
@@ -268,6 +268,9 @@ def convert_au_files_to_wav(src_paths_by_channel, dst_path):
 					for i, v in enumerate(samples):
 						# We want 16-bit PCM
 						samples[i] = int(v * 32767.0)
+						#clipping. 16-bit PCM doesn't support the entire range of 32-bit
+						samples[i] = min(samples[i], 32767) #too high
+						samples[i] = max(samples[i], -32767) #too low
 				elif au['encoding'] == AU_SAMPLE_FORMAT_24:
 					print("ERROR: 24 bits not supported")
 					return


### PR DESCRIPTION
This pull request solves my issue ' Error Parsing some wavs #3 '

When the function `convert_au_files_to_wav` tries to convert float data to 16-bit, it doesn't account for data outside the interval [-32767, 32767]. 

With this pull it will cutoff data which are above that threshhold so that the 16-bit PCM WAV can be written.